### PR TITLE
Significant performance improvements by enabling query cache

### DIFF
--- a/mysql-5.5/default.cnf
+++ b/mysql-5.5/default.cnf
@@ -25,3 +25,7 @@ innodb_large_prefix = 1
 
 # Max packets
 max_allowed_packet = 128M
+
+# Enable query cache
+query_cache_type = 1
+query_cache_size = 32M

--- a/mysql-5.5/mysql-variables.txt
+++ b/mysql-5.5/mysql-variables.txt
@@ -18,3 +18,5 @@ innodb_large_prefix	ON
 innodb_log_buffer_size	8388608
 innodb_log_file_size	134217728
 max_allowed_packet	134217728
+query_cache_size	33554432
+query_cache_type	ON

--- a/mysql-5.6/default.cnf
+++ b/mysql-5.6/default.cnf
@@ -25,3 +25,7 @@ innodb_large_prefix = 1
 
 # Max packets
 max_allowed_packet = 128M
+
+# Enable query cache
+query_cache_type = 1
+query_cache_size = 32M

--- a/mysql-5.6/mysql-variables.txt
+++ b/mysql-5.6/mysql-variables.txt
@@ -18,3 +18,5 @@ innodb_large_prefix	ON
 innodb_log_buffer_size	8388608
 innodb_log_file_size	134217728
 max_allowed_packet	134217728
+query_cache_size	33554432
+query_cache_type	ON

--- a/mysql-5.7/default.cnf
+++ b/mysql-5.7/default.cnf
@@ -21,3 +21,7 @@ innodb_file_per_table = 1
 
 # Max packets
 max_allowed_packet = 128M
+
+# Enable query cache
+query_cache_type = 1
+query_cache_size = 32M

--- a/mysql-5.7/mysql-variables.txt
+++ b/mysql-5.7/mysql-variables.txt
@@ -18,3 +18,5 @@ innodb_large_prefix	ON
 innodb_log_buffer_size	8388608
 innodb_log_file_size	134217728
 max_allowed_packet	134217728
+query_cache_size	33554432
+query_cache_type	ON


### PR DESCRIPTION
The base MySQL images do not enable the query cache, enabling which can lead to significant performance improvements. This pull request enables the query cache and sets it to 32M, which is the Debian default. We've seen response time improvements of anywhere between 10% and 30% on query-heavy applications.

Since I do not know of any MySQL instance running in production or otherwise with query cache disabled, this might be a no-brainer to instantly improve performance for all applications running locally with Docksal.