### PR TITLE
Fix MySQL 5.5 PATH environment in /etc/profile

### DIFF
--- a/mysql-5.5/Dockerfile
+++ b/mysql-5.5/Dockerfile
@@ -10,3 +10,6 @@ RUN set -xe; \
 	sed -i '/\$(id -u)/ r /usr/local/bin/docker-entrypoint.d.sh' /usr/local/bin/docker-entrypoint.sh
 # Init scripts run under root
 COPY docker-entrypoint.d /docker-entrypoint.d
+
+# Fix PATH to include MySQL 5.5 binaries
+RUN echo 'PATH=$PATH:/usr/local/mysql/bin:/usr/local/mysql/scripts' >> /etc/profile


### PR DESCRIPTION
Fixes #10. As far as I can tell, this is only necessary for the 5.5 base image since that contains an explicit `PATH` environment variable in the Dockerfile.