### PR TITLE
Use the older (pre 8.0.4) authentication method

### DIFF
--- a/8.0/default.cnf
+++ b/8.0/default.cnf
@@ -20,5 +20,10 @@ innodb_log_file_size = 128MB
 
 innodb_file_per_table = 1
 
+# Use the older (pre 8.0.4) authentication method for (backward) compatibility between MySQL/MariaDB
+# See https://mariadb.com/kb/en/authentication-plugin-sha-256/
+# See https://stackoverflow.com/questions/49963383/authentication-plugin-caching-sha2-password
+default_authentication_plugin = mysql_native_password
+
 # Max packets
 max_allowed_packet = 128M


### PR DESCRIPTION
... for (backward) compatibility between MySQL/MariaDB

See https://mariadb.com/kb/en/authentication-plugin-sha-256/
See https://stackoverflow.com/questions/49963383/authentication-plugin-caching-sha2-password

Fixes #19 