### PR TITLE
Release 2.0.1

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-mysqladmin ping -u root --password=$MYSQL_ROOT_PASSWORD | grep -i 'mysqld is alive' || exit 1
+mysqladmin ping --host=127.0.0.1 --port=3306 --user=root --password=$MYSQL_ROOT_PASSWORD | grep -i 'mysqld is alive' || exit 1
 
 exit 0


### PR DESCRIPTION
- Fixed `healthcheck.sh`
  - Removed ambiguity around the `mysqladmin` connection string by specifying host/port
