### PR TITLE
Release 2.0.2

### DIFF
--- a/8.0/default.cnf
+++ b/8.0/default.cnf
@@ -1,5 +1,7 @@
 [client]
 default-character-set = utf8mb4
+# mysql:8.0-oracle upstream image does not set the socket location for mysql clients, so we have to set it here
+socket = /var/run/mysqld/mysqld.sock
 
 [mysql]
 default-character-set = utf8mb4


### PR DESCRIPTION
- Set socket in the client section in MySQL config overrides 
  - `mysql:8.0-oracle` upstream image does not set the `socket` location for mysql clients
  - Fixes socket connections errors from `mysql` (client) and `mysqladmin` when running inside the container.
